### PR TITLE
Add ability for users to sort cards in "My Cards" page

### DIFF
--- a/public/javascripts/router.js
+++ b/public/javascripts/router.js
@@ -100,17 +100,25 @@ $(function ($, _, Backbone) {
       $("body div.process-loading").show();
 
       // Get the user's cards and set the card list view
-      new cantas.models.CardCollection().fetch({
-        // Needs to be the same as the morphed filters in 
-        // cantas.views.CardFilterPanelView
-        data: {
+      new cantas.models.CardCollection()
+
+        // .setPage(1)
+
+        .setFilters({
           $or: [
             { creatorId: cantas.user.id },
             { assignees: cantas.user.id },
             { subscribeUserIds: cantas.user.id }
           ],
           isArchived: false
-        },
+        })
+
+        .setSort({
+          created: -1,
+          title: 1
+        })
+
+        .fetch({
         success: function(collection) {
           $("body div.process-loading").hide();
 

--- a/public/javascripts/views/cardList.js
+++ b/public/javascripts/views/cardList.js
@@ -84,6 +84,14 @@
         })
       );
 
+      // Add card sorting panel
+      sidebarView.addPanel(
+        new cantas.views.CardSortPanelView({
+          context: sidebarView,
+          collection: this.collection
+        })
+      );
+
       this.$el.append(sidebarView.$el);
     },
 

--- a/public/javascripts/views/sidebar.js
+++ b/public/javascripts/views/sidebar.js
@@ -237,8 +237,8 @@
     filterCollection: function() {
       $("body div.process-loading").show();
       this.getFilters();
+      this.collection.setFilters(this.morphFilters());
       this.collection.fetch({
-        data: this.morphFilters(),
         reset: true,
         success: function() {
           $("body div.process-loading").hide();
@@ -387,6 +387,122 @@
       };
     },
 
+
+    remove: function() {
+      this.undelegateEvents();
+      this.$el.remove();
+      this.stopListening();
+    }
+
+  });
+
+
+
+  /**
+   * Panel for sorting cards
+   */
+  cantas.views.CardSortPanelView = cantas.views.BaseView.extend({
+
+    context: null,
+    isOpen: false,
+
+    defaultSort: {
+      field: 'created',
+      order: 'DESC'
+    },
+
+    className: "sidebar-panel panel-sort",
+    id: _.uniqueId('card-panel-'),
+
+    template: jade.compile($("#template-card-sort-panel-view").text()),
+    linkTemplate: jade.compile($("#template-card-sort-panel-link-view").text()),
+
+    events: {
+      'submit .js-sort-form': 'submitAction'
+    },
+
+    initialize: function() {
+      this.context = this.options.context;
+      this.sort = this.defaultSort;
+      return this;
+    },
+
+    /**
+     * Render the sidebar and panels
+     */
+    render: function(context) {
+      this.delegateEvents();
+      this.$el.html(this.template(this.sort));
+      return this;
+    },
+
+    /**
+     * Get the sidebar link markup (gets called by the sidebar)
+     */
+    renderLink: function() {
+      return $(this.linkTemplate({
+        panel: this.id
+      }));
+    },
+
+    submitAction: function(e) {
+      e.preventDefault();
+      this.sortCollection();
+      this.context.renderSidebar();
+    },
+
+    /**
+     * Read the currently set sort options and apply to collection
+     */
+    sortCollection: function() {
+      $("body div.process-loading").show();
+      this.getSortOptions();
+      this.collection.setSort(this.morphSort());
+      this.collection.fetch({
+        reset: true,
+        success: function() {
+          $("body div.process-loading").hide();
+        },
+        error: function() {
+          $("body div.process-loading").hide();
+        }
+      });
+    },
+
+    /**
+     * Get sort options from the form 
+     */
+    getSortOptions: function() {
+      this.sort = _.extend({}, this.defaultSort, {
+        field: this.$('.js-cardsort-field:checked').val(),
+        order: this.$('.js-cardsort-order:checked').val()
+      });
+      return this.sort;
+    },
+
+    /**
+     * Morph the sort into a query
+     */
+    morphSort: function() {
+      var morphed = {},
+        order = (this.sort.order === 'ASC') ? 1 : -1;
+
+      switch (this.sort.field) {
+      case "board":
+        morphed.boardId = order;
+        break;
+      case "due":
+        morphed.dueDate = order;
+        break;
+      default:
+        morphed.created = order;
+        break;
+      }
+
+      morphed.title = 1;
+
+      return morphed;
+    },
 
     remove: function() {
       this.undelegateEvents();

--- a/public/stylesheets/project.css
+++ b/public/stylesheets/project.css
@@ -819,9 +819,12 @@ input:focus, textarea:focus{
     color: #fff;
 }
 
-.filter-group {
+.panel-group {
     margin-bottom: 15px;
+}
 
+.panel-group-title {
+    margin-bottom: 5px;
 }
 
 .sidebar-items i {

--- a/sockets/crud/base.js
+++ b/sockets/crud/base.js
@@ -438,6 +438,69 @@
   };
 
 
+
+  /**
+   * Build a mongoose query from an object
+   *
+   * For example; 
+   *   - Providing options { $limit: 100, $sort: { created: -1 }, $populate: 'assignees', etc... }
+   *   - Would return query.sort({ created: -1 },).populate('assignees').limit(100)...
+   *
+   * @param  {object}    query     mongoose query
+   * @param  {object}    options   extend query with...
+   * @return {object} mongoose query
+   */
+  BaseCRUD.prototype._buildQuery = function(query, options) {
+
+    var methods = {};
+
+    // Add the permitted methods here
+    _.forIn(options, function(value, key) {
+      switch (key) {
+      case "$sort":
+        methods.sort = value;
+        delete options.$sort;
+        break;
+
+      case "$limit":
+        methods.limit = value;
+        delete options.$limit;
+        break;
+
+      case "$skip":
+        methods.skip = value;
+        delete options.$skip;
+        break;
+
+      case "$populate":
+        methods.populate = value;
+        delete options.$populate;
+        break;
+
+      case "$query":
+        methods.find = value;
+        delete options.$query;
+        break;
+      }
+    });
+
+    if (!methods.find) {
+      methods.find = options;
+    }
+
+    // Find should always be run first
+    query = query.find(methods.find);
+    delete methods.find;
+
+    _.each(methods, function(value, key) {
+      query[key](value);
+    });
+
+    return query;
+  };
+
+
+
   module.exports = BaseCRUD;
 
 }(module));

--- a/sockets/crud/card.js
+++ b/sockets/crud/card.js
@@ -12,6 +12,7 @@
   var notification = require("../../services/notification");
   var cantasUtils = require('../../services/utils');
   var signals = require("../signals");
+  var _ = require('lodash');
 
   function CardCRUD(options) {
     BaseCRUD.call(this, options);
@@ -94,7 +95,10 @@
   };
 
   CardCRUD.prototype._read = function(data, callback) {
+
+    // Parse special value types in the query
     data = this._parseQuery(data);
+
     if (data) {
       if (data._id) {
         this.modelClass.findOne(data).populate("assignees").exec(
@@ -103,7 +107,13 @@
           }
         );
       } else {
-        this.modelClass.find(data).populate("assignees").exec(
+
+        // Build a query from the request data (Allows for limit, skip, sorting, etc.)
+        var query = this._buildQuery(this.modelClass, _.extend({}, data, {
+          $populate: "assignees"
+        }));
+
+        query.exec(
           function (err, result) {
             async.map(
               result,

--- a/views/backbone/sidebar.jade
+++ b/views/backbone/sidebar.jade
@@ -3,14 +3,15 @@ script#template-sidebar-view(type="text/template").
     ul(class='sidebar-items')
   div(class='panel-container')
 
+
 script#template-card-filter-panel-view(type="text/template").
   h3.panel-title Filter Cards
   form(class='filter-form js-filter-form')
-    div(class='filter-group')
-      h5(class='filter-title') Filter By Keyword
+    div(class='panel-group')
+      h5(class='panel-group-title') Filter By Keyword
       input(type='text', placeholder='Enter keyword...', class='js-cardfilter-keyword', name='keyword', value=keyword)
-    div(class='filter-group')
-      h5(class='filter-title') Show Cards
+    div(class='panel-group')
+      h5(class='panel-group-title') Show Cards
       label(class='checkbox')
         input(type='checkbox', class='js-cardfilter-created', name='created', checked=(created ? 'checked' : undefined))
         | Created By Me
@@ -20,8 +21,8 @@ script#template-card-filter-panel-view(type="text/template").
       label(class='checkbox')
         input(type='checkbox', class='js-cardfilter-assigned', name='assigned', checked=(assigned ? 'checked' : undefined))
         | Assigned to me
-    div(class='filter-group')
-      h5(class='filter-title') Due Date
+    div(class='panel-group')
+      h5(class='panel-group-title') Due Date
       label(class='radio')
         input(type='radio', class='js-cardfilter-dueDate', name='dueDate', value='day', checked=(dueDate=='day' ? 'checked' : undefined))
         | Within the next day
@@ -34,13 +35,13 @@ script#template-card-filter-panel-view(type="text/template").
       label(class='radio')
         input(type='radio', class='js-cardfilter-dueDate', name='dueDate', value='any', checked=(dueDate=='any' ? 'checked' : undefined))
         | Anytime
-    div(class='filter-group')
-      h5(class='filter-title') Hidden Cards
+    div(class='panel-group')
+      h5(class='panel-group-title') Hidden Cards
       label(class='checkbox')
         input(type='checkbox', class='js-cardfilter-archived', name='archived', checked=(archived ? 'checked' : undefined))
         | Show archived cards
     div(class='form-footer')
-      input(type='submit', class='btn btn-warning', value='filter')
+      input(type='submit', class='btn btn-warning', value='Filter Cards')
 
 
 script#template-card-filter-panel-link-view(type="text/template").
@@ -48,3 +49,35 @@ script#template-card-filter-panel-link-view(type="text/template").
     a(title='Filter Cards')
       i(class='icon icon-filter')
       span(class='badge badge-important')= total
+
+
+script#template-card-sort-panel-view(type="text/template").
+  h3.panel-title Sort Cards
+  form(class='sort-form js-sort-form')
+    div(class='panel-group')
+      h5(class='panel-group-title') Sort Cards By
+      label(class='radio')
+        input(type='radio', class='js-cardsort-field', name='sort-field', value='created', checked=(field=='created' ? 'checked' : undefined))
+        | Date Created
+      label(class='radio')
+        input(type='radio', class='js-cardsort-field', name='sort-field', value='board', checked=(field=='board' ? 'checked' : undefined))
+        | Board
+      label(class='radio')
+        input(type='radio', class='js-cardsort-field', name='sort-field', value='due', checked=(field=='due' ? 'checked' : undefined))
+        | Due Date
+    div(class='panel-group')
+      h5(class='panel-group-title') Order
+      label(class='radio')
+        input(type='radio', class='js-cardsort-order', name='sort-order', value='ASC', checked=(order=='ASC' ? 'checked' : undefined))
+        | Ascending
+      label(class='radio')
+        input(type='radio', class='js-cardsort-order', name='sort-order', value='DESC', checked=(order=='DESC' ? 'checked' : undefined))
+        | Descending
+    div(class='form-footer')
+      input(type='submit', class='btn btn-warning', value='Sort Cards')
+
+
+script#template-card-sort-panel-link-view(type="text/template").
+  li(data-panel=panel)
+    a(title='Sort Cards')
+      i(class='icon icon-sort')


### PR DESCRIPTION
Users can now sort cards by the following fields
- Date created at
- Due date
- Board

When sorting cards by board they are not grouped by board name, just by the board they belong to. This is because Mongoose doesn't support sorting by fields from referenced documents. Changing this would need a big refactor and would have a negative impact on performance. Not sure if it is worth it?

Sorting also works with other filters.
