### PR TITLE
REV: use npm-shrinkwrap to limited npm version

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,967 @@
+{
+  "name": "cantas",
+  "version": "1.0.0",
+  "dependencies": {
+    "async": {
+      "version": "0.8.0",
+      "from": "async@0.8.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz"
+    },
+    "connect-redis": {
+      "version": "1.4.7",
+      "from": "connect-redis@1.4.7",
+      "dependencies": {
+        "debug": {
+          "version": "0.8.1",
+          "from": "debug@0.8.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+        }
+      }
+    },
+    "easyimage": {
+      "version": "0.1.6",
+      "from": "easyimage@0.1.6",
+      "resolved": "https://registry.npmjs.org/easyimage/-/easyimage-0.1.6.tgz"
+    },
+    "express": {
+      "version": "2.5.11",
+      "from": "express@2.5.11",
+      "dependencies": {
+        "connect": {
+          "version": "1.9.2",
+          "from": "connect@1.9.2",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+          "dependencies": {
+            "formidable": {
+              "version": "1.0.14",
+              "from": "formidable@1.0.14"
+            }
+          }
+        },
+        "mime": {
+          "version": "1.2.4",
+          "from": "mime@1.2.4"
+        },
+        "qs": {
+          "version": "0.4.2",
+          "from": "qs@0.4.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "from": "mkdirp@0.3.0"
+        }
+      }
+    },
+    "jade": {
+      "version": "1.3.1",
+      "from": "jade@1.3.1",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.3.1.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.1.0",
+          "from": "commander@2.1.0"
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@0.3.5"
+        },
+        "transformers": {
+          "version": "2.1.0",
+          "from": "transformers@2.1.0",
+          "dependencies": {
+            "promise": {
+              "version": "2.0.0",
+              "from": "promise@2.0.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+              "dependencies": {
+                "is-promise": {
+                  "version": "1.0.0",
+                  "from": "is-promise@1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.0.tgz"
+                }
+              }
+            },
+            "css": {
+              "version": "1.0.8",
+              "from": "css@1.0.8",
+              "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "dependencies": {
+                "css-parse": {
+                  "version": "1.0.4",
+                  "from": "css-parse@1.0.4"
+                },
+                "css-stringify": {
+                  "version": "1.0.5",
+                  "from": "css-stringify@1.0.5"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.2.5",
+              "from": "uglify-js@2.2.5",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.33",
+                  "from": "source-map@0.1.33",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@0.1.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@0.3.7",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "character-parser": {
+          "version": "1.2.0",
+          "from": "character-parser@1.2.0"
+        },
+        "monocle": {
+          "version": "1.1.51",
+          "from": "monocle@1.1.51",
+          "dependencies": {
+            "readdirp": {
+              "version": "0.2.5",
+              "from": "readdirp@0.2.5",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@0.2.14",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "with": {
+          "version": "3.0.0",
+          "from": "with@3.0.0",
+          "resolved": "https://registry.npmjs.org/with/-/with-3.0.0.tgz",
+          "dependencies": {
+            "uglify-js": {
+              "version": "2.4.13",
+              "from": "uglify-js@2.4.13",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.33",
+                  "from": "source-map@0.1.33",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@0.1.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@0.3.7",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "constantinople": {
+          "version": "2.0.0",
+          "from": "constantinople@2.0.0",
+          "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-2.0.0.tgz",
+          "dependencies": {
+            "uglify-js": {
+              "version": "2.4.13",
+              "from": "uglify-js@2.4.13",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.13.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@0.2.10",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.33",
+                  "from": "source-map@0.1.33",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.33.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@0.1.0",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@0.3.7",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@1.0.2",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "2.4.1",
+      "from": "lodash@2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+    },
+    "markdown": {
+      "version": "0.5.0",
+      "from": "markdown@0.5.0",
+      "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "2.1.2",
+          "from": "nopt@2.1.2",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@1.0.5",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.6.0",
+      "from": "moment@2.6.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.6.0.tgz"
+    },
+    "mongoose": {
+      "version": "3.8.8",
+      "from": "mongoose@3.8.8",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.8.8.tgz",
+      "dependencies": {
+        "hooks": {
+          "version": "0.2.1",
+          "from": "hooks@0.2.1",
+          "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz"
+        },
+        "mongodb": {
+          "version": "1.3.23",
+          "from": "mongodb@1.3.23",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.3.23.tgz",
+          "dependencies": {
+            "bson": {
+              "version": "0.2.5",
+              "from": "bson@0.2.5",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.5.tgz"
+            },
+            "kerberos": {
+              "version": "0.0.3",
+              "from": "kerberos@0.0.3"
+            }
+          }
+        },
+        "ms": {
+          "version": "0.1.0",
+          "from": "ms@0.1.0"
+        },
+        "sliced": {
+          "version": "0.0.5",
+          "from": "sliced@0.0.5"
+        },
+        "muri": {
+          "version": "0.3.1",
+          "from": "muri@0.3.1"
+        },
+        "mpromise": {
+          "version": "0.4.3",
+          "from": "mpromise@0.4.3",
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.4.3.tgz"
+        },
+        "mpath": {
+          "version": "0.1.1",
+          "from": "mpath@0.1.1"
+        },
+        "regexp-clone": {
+          "version": "0.0.1",
+          "from": "regexp-clone@0.0.1"
+        },
+        "mquery": {
+          "version": "0.5.3",
+          "from": "mquery@0.5.3",
+          "resolved": "https://registry.npmjs.org/mquery/-/mquery-0.5.3.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "node-krb5": {
+      "version": "0.0.3",
+      "from": "node-krb5@0.0.3",
+      "resolved": "https://registry.npmjs.org/node-krb5/-/node-krb5-0.0.3.tgz",
+      "dependencies": {
+        "node-gyp": {
+          "version": "0.7.2",
+          "from": "node-gyp@0.7.2",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.9",
+              "from": "glob@3.2.9",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.9.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            },
+            "fstream": {
+              "version": "0.1.25",
+              "from": "fstream@0.1.25",
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.25.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "2.0.3",
+                  "from": "graceful-fs@~2.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@~0.2.11",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@0.3.5"
+            },
+            "nopt": {
+              "version": "2.2.1",
+              "from": "nopt@2.2.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@1.0.5",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            },
+            "npmlog": {
+              "version": "0.0.6",
+              "from": "npmlog@0.0.6",
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.0.6.tgz",
+              "dependencies": {
+                "ansi": {
+                  "version": "0.2.1",
+                  "from": "ansi@0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.2.1.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3"
+            },
+            "request": {
+              "version": "2.9.203",
+              "from": "request@2.9.203",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.8",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "semver": {
+              "version": "1.1.4",
+              "from": "semver@1.1.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
+            },
+            "tar": {
+              "version": "0.1.19",
+              "from": "tar@0.1.19",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.19.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "block-stream": {
+                  "version": "0.0.7",
+                  "from": "block-stream@0.0.7",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.5",
+              "from": "which@~1.0.5",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "nodemailer": {
+      "version": "0.6.3",
+      "from": "nodemailer@0.6.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-0.6.3.tgz",
+      "dependencies": {
+        "mailcomposer": {
+          "version": "0.2.9",
+          "from": "mailcomposer@0.2.9",
+          "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-0.2.9.tgz",
+          "dependencies": {
+            "mimelib": {
+              "version": "0.2.14",
+              "from": "mimelib@0.2.14",
+              "resolved": "https://registry.npmjs.org/mimelib/-/mimelib-0.2.14.tgz",
+              "dependencies": {
+                "encoding": {
+                  "version": "0.1.7",
+                  "from": "encoding@0.1.7",
+                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.7.tgz",
+                  "dependencies": {
+                    "iconv-lite": {
+                      "version": "0.2.11",
+                      "from": "iconv-lite@0.2.11",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+                    }
+                  }
+                },
+                "addressparser": {
+                  "version": "0.2.1",
+                  "from": "addressparser@0.2.1",
+                  "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.2.1.tgz"
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@~1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "punycode": {
+              "version": "1.2.4",
+              "from": "punycode@1.2.4",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+            },
+            "follow-redirects": {
+              "version": "0.0.3",
+              "from": "follow-redirects@0.0.3",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.6.0",
+                  "from": "underscore@1.6.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+                }
+              }
+            },
+            "dkim-signer": {
+              "version": "0.1.0",
+              "from": "dkim-signer@0.1.0",
+              "resolved": "https://registry.npmjs.org/dkim-signer/-/dkim-signer-0.1.0.tgz"
+            }
+          }
+        },
+        "simplesmtp": {
+          "version": "0.3.29",
+          "from": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.29.tgz",
+          "resolved": "https://registry.npmjs.org/simplesmtp/-/simplesmtp-0.3.29.tgz",
+          "dependencies": {
+            "rai": {
+              "version": "0.1.10",
+              "from": "rai@0.1.10",
+              "resolved": "https://registry.npmjs.org/rai/-/rai-0.1.10.tgz"
+            },
+            "xoauth2": {
+              "version": "0.1.8",
+              "from": "xoauth2@0.1.8",
+              "resolved": "https://registry.npmjs.org/xoauth2/-/xoauth2-0.1.8.tgz"
+            }
+          }
+        },
+        "directmail": {
+          "version": "0.1.6",
+          "from": "directmail@0.1.6",
+          "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.6.tgz"
+        },
+        "he": {
+          "version": "0.3.6",
+          "from": "he@0.3.6",
+          "resolved": "https://registry.npmjs.org/he/-/he-0.3.6.tgz"
+        },
+        "public-address": {
+          "version": "0.1.0",
+          "from": "public-address@0.1.0",
+          "resolved": "https://registry.npmjs.org/public-address/-/public-address-0.1.0.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13-1",
+          "from": "readable-stream@1.1.13-1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@1.0.1",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1"
+            },
+            "string_decoder": {
+              "version": "0.10.25-1",
+              "from": "string_decoder@0.10.25-1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1"
+            }
+          }
+        }
+      }
+    },
+    "passport": {
+      "version": "0.2.0",
+      "from": "passport@0.2.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.2.0.tgz",
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "from": "passport-strategy@1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
+        },
+        "pause": {
+          "version": "0.0.1",
+          "from": "pause@0.0.1"
+        }
+      }
+    },
+    "passport-google": {
+      "version": "0.3.0",
+      "from": "passport-google@0.3.0",
+      "resolved": "https://registry.npmjs.org/passport-google/-/passport-google-0.3.0.tgz",
+      "dependencies": {
+        "pkginfo": {
+          "version": "0.2.3",
+          "from": "pkginfo@0.2.3"
+        },
+        "passport-openid": {
+          "version": "0.3.1",
+          "from": "passport-openid@0.3.1",
+          "resolved": "https://registry.npmjs.org/passport-openid/-/passport-openid-0.3.1.tgz",
+          "dependencies": {
+            "passport": {
+              "version": "0.1.18",
+              "from": "passport@0.1.18",
+              "dependencies": {
+                "pause": {
+                  "version": "0.0.1",
+                  "from": "pause@0.0.1"
+                }
+              }
+            },
+            "openid": {
+              "version": "0.5.9",
+              "from": "openid@0.5.9",
+              "resolved": "https://registry.npmjs.org/openid/-/openid-0.5.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "from": "passport-local@1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "dependencies": {
+        "passport-strategy": {
+          "version": "1.0.0",
+          "from": "passport-strategy@1.0.0",
+          "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz"
+        }
+      }
+    },
+    "redis": {
+      "version": "0.10.1",
+      "from": "redis@0.10.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-0.10.1.tgz"
+    },
+    "requestify": {
+      "version": "0.1.16",
+      "from": "requestify@0.1.16",
+      "resolved": "https://registry.npmjs.org/requestify/-/requestify-0.1.16.tgz",
+      "dependencies": {
+        "q": {
+          "version": "0.9.7",
+          "from": "q@0.9.7"
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "from": "underscore@1.4.4"
+        },
+        "jquery": {
+          "version": "1.8.3",
+          "from": "jquery@1.8.3",
+          "dependencies": {
+            "jsdom": {
+              "version": "0.2.19",
+              "from": "jsdom@0.2.19",
+              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-0.2.19.tgz",
+              "dependencies": {
+                "request": {
+                  "version": "2.34.0",
+                  "from": "request@2.34.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.34.0.tgz",
+                  "dependencies": {
+                    "qs": {
+                      "version": "0.6.6",
+                      "from": "qs@0.6.6"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.0",
+                      "from": "json-stringify-safe@5.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@0.5.2",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.1",
+                      "from": "node-uuid@1.4.1",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@1.2.11",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "0.12.1",
+                      "from": "tough-cookie@0.12.1",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                      "dependencies": {
+                        "punycode": {
+                          "version": "1.2.4",
+                          "from": "punycode@1.2.4",
+                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                        }
+                      }
+                    },
+                    "form-data": {
+                      "version": "0.1.2",
+                      "from": "form-data@0.1.2",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.4",
+                          "from": "combined-stream@0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.4.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5"
+                            }
+                          }
+                        },
+                        "async": {
+                          "version": "0.2.10",
+                          "from": "async@0.2.10",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                        }
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.3.0",
+                      "from": "tunnel-agent@0.3.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.0",
+                      "from": "http-signature@0.10.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.2",
+                          "from": "assert-plus@0.1.2"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11"
+                        },
+                        "ctype": {
+                          "version": "0.5.2",
+                          "from": "ctype@0.5.2"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.3.0",
+                      "from": "oauth-sign@0.3.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.0.0",
+                      "from": "hawk@1.0.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.1",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.2",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.2",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.4",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@0.5.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    }
+                  }
+                },
+                "cssom": {
+                  "version": "0.2.5",
+                  "from": "cssom@0.2.5",
+                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.2.5.tgz"
+                },
+                "cssstyle": {
+                  "version": "0.2.11",
+                  "from": "cssstyle@0.2.11",
+                  "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.11.tgz",
+                  "dependencies": {
+                    "cssom": {
+                      "version": "0.3.0",
+                      "from": "cssom@0.3.0",
+                      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "htmlparser": {
+              "version": "1.7.6",
+              "from": "htmlparser@1.7.6"
+            },
+            "xmlhttprequest": {
+              "version": "1.4.2",
+              "from": "xmlhttprequest@1.4.2"
+            },
+            "location": {
+              "version": "0.0.1",
+              "from": "location@0.0.1"
+            },
+            "navigator": {
+              "version": "1.0.1",
+              "from": "navigator@1.0.1",
+              "resolved": "https://registry.npmjs.org/navigator/-/navigator-1.0.1.tgz"
+            },
+            "contextify": {
+              "version": "0.1.7",
+              "from": "contextify@0.1.7",
+              "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.7.tgz",
+              "dependencies": {
+                "bindings": {
+                  "version": "1.2.0",
+                  "from": "bindings@1.2.0",
+                  "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.0.tgz"
+                },
+                "nan": {
+                  "version": "0.8.0",
+                  "from": "nan@0.8.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "socket.io": {
+      "version": "0.9.16",
+      "from": "socket.io@0.9.16",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+      "dependencies": {
+        "socket.io-client": {
+          "version": "0.9.16",
+          "from": "socket.io-client@0.9.16",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+          "dependencies": {
+            "uglify-js": {
+              "version": "1.2.5",
+              "from": "uglify-js@1.2.5",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz"
+            },
+            "ws": {
+              "version": "0.4.31",
+              "from": "ws@0.4.31",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1"
+                },
+                "nan": {
+                  "version": "0.3.2",
+                  "from": "nan@0.3.2",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                },
+                "tinycolor": {
+                  "version": "0.0.1",
+                  "from": "tinycolor@0.0.1",
+                  "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                },
+                "options": {
+                  "version": "0.0.5",
+                  "from": "options@0.0.5",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
+                }
+              }
+            },
+            "xmlhttprequest": {
+              "version": "1.4.2",
+              "from": "xmlhttprequest@1.4.2"
+            },
+            "active-x-obfuscator": {
+              "version": "0.0.1",
+              "from": "active-x-obfuscator@0.0.1",
+              "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+              "dependencies": {
+                "zeparser": {
+                  "version": "0.0.5",
+                  "from": "zeparser@0.0.5"
+                }
+              }
+            }
+          }
+        },
+        "policyfile": {
+          "version": "0.0.4",
+          "from": "policyfile@0.0.4"
+        },
+        "base64id": {
+          "version": "0.1.0",
+          "from": "base64id@0.1.0"
+        },
+        "redis": {
+          "version": "0.7.3",
+          "from": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
+        }
+      }
+    },
+    "xmlrpc": {
+      "version": "1.1.1",
+      "from": "xmlrpc@1.1.1",
+      "dependencies": {
+        "sax": {
+          "version": "0.4.3",
+          "from": "sax@0.4.3",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.4.3.tgz"
+        },
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "xmlbuilder@0.4.2"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "passport-local": "*",
         "passport-google": "*",
         "redis": "*",
-        "socket.io": "*",
+        "socket.io": "~0.9.x",
         "xmlrpc": "~1.1.0",
         "easyimage": "*",
         "requestify": "*",


### PR DESCRIPTION
socket.io update to 1.0, it is incompatible with current cantas.
