### PR TITLE
issue 58 - markdown links moved to footer, now only open in new window/tab

### DIFF
--- a/public/javascripts/views/card.js
+++ b/public/javascripts/views/card.js
@@ -761,7 +761,6 @@
     events: {
       "click .js-edit-title": "openEditTitleDialog",
       "click .js-edit-desc": "openEditDescDialog",
-      "click .js-edit-desc a": "openNewTab",
       "click .js-save-title": "onTitleSaveClick",
       "click .js-cancel-title": "onTitleCancelClick",
       "click .js-save-desc": "onDescriptionSaveClick",
@@ -1028,12 +1027,6 @@
       this.$el.find(".js-edit-desc").hide();
       this.$el.find(".js-edit-desc-area").show();
       this.$el.find(".js-desc-input").val(this.model.get("description")).select();
-    },
-
-    openNewTab: function(event) {
-      event.stopPropagation();
-      event.preventDefault();
-      window.open($(event.target).attr('href'));
     },
 
     onDescriptionSaveClick: function(event) {

--- a/public/stylesheets/project.css
+++ b/public/stylesheets/project.css
@@ -2856,6 +2856,11 @@ card{
   display: none;
 }
 
+.footer-left {
+  float: left;
+  padding: 4px;
+}
+
 /*=================Checklist=====================*/
 .checklist{
   margin-bottom: 18px;

--- a/views/backbone/card-detail.jade
+++ b/views/backbone/card-detail.jade
@@ -43,7 +43,6 @@ script#template-card-detail-view(type="text/template")
   |          span Comment
   |    section.card-option.card-description
   |      h4.desc.card-detail-desc.js-edit-desc.js-desc(title="Click to edit...")!= card.description
-  |        a.new-item(href="http://daringfireball.net/projects/markdown/syntax") Markdown Syntax
   |      a: span.new-item.js-edit-desc Edit Card Description
   |      div.card-option-edit.js-edit-desc-area
   |        textarea.js-desc-input(placeholder="Add description")
@@ -53,4 +52,6 @@ script#template-card-detail-view(type="text/template")
   |    section.card-option.attachment
   |    section.card-option.comment
   |  div.modal-footer
+  |    a.new-item.markdown-help.footer-left(href="http://daringfireball.net/projects/markdown/syntax", target="_blank") Markdown Syntax Help 
+  |      i.fa.icon-external-link
   |    a.btn.js-close-card-detail(data-dismiss="modal", href="javascript: void(0)") Close

--- a/views/backbone/comment.jade
+++ b/views/backbone/comment.jade
@@ -1,6 +1,5 @@
 script#template-comment-view(type="text/template")
   |h4 Comment
-  |  a.new-item(href="http://daringfireball.net/projects/markdown/syntax") Markdown Syntax
   |textarea.js-add-comment-input(placeholder="Add comment")
   |div.js-comment-controls.hide.comment-button
   |  button.btn.btn-primary.js-save-comment Save


### PR DESCRIPTION
- removed old links, new link in footer
- using target="_blank" instead of javascript
- removed unused javascript function
- fa icon also now displaying
