### PR TITLE
fix #94

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -2,10 +2,14 @@
 
   "use strict";
 
+  var authUtils = require('../services/auth/utils');
+  var servicesUtils = require('../services/utils');
   var mongoose = require('mongoose');
   var Schema = mongoose.Schema;
   var ObjectId = Schema.ObjectId;
   var UserSchema;
+
+  var MAX_PASSWORD_LENGTH = 64;
 
   UserSchema = new Schema({
     username: { type: String, required: true, lowercase: true, unique: true },
@@ -28,6 +32,51 @@
     var conditions = { $or: [{ username: identity }, { email: identity }] };
     this.findOne(conditions, "username", function(err, user) {
       callback(user !== undefined && user !== null);
+    });
+  };
+
+  // Instance methods
+
+  UserSchema.methods.verifyUserPassword = function(password) {
+    if (password === undefined || password === null || password.length === 0) {
+      throw Error('No password to set.');
+    }
+    if (password.length > MAX_PASSWORD_LENGTH) {
+      throw Error('Password is too long.');
+    }
+  };
+
+  /*
+   * Set user's password.
+   */
+  UserSchema.methods.setPassword = function(rawPassword, callback) {
+    this.verifyUserPassword(rawPassword);
+    var password = authUtils.makePassword(rawPassword);
+    this.model('User').findByIdAndUpdate(this._id, {$set: {password: password}}, function(err, user) {
+      callback(err === null);
+    });
+  };
+
+  /*
+   * Set an unusable password to user.
+   */
+  UserSchema.methods.setUnusablePassword = function(callback) {
+    var password = servicesUtils.randomString();
+    this.setPassword(password, callback);
+  };
+
+  /*
+   * Check whether user has a password.
+   */
+  UserSchema.methods.checkPassword = function(rawPassword, callback) {
+    this.verifyUserPassword(rawPassword);
+    this.model('User').findById(this._id, 'password', function(err, user) {
+      if (err) {
+        callback(false);
+      } else {
+        var isValid = authUtils.checkPassword(rawPassword, user.password);
+        callback(isValid);
+      }
     });
   };
 

--- a/models/user.js
+++ b/models/user.js
@@ -39,10 +39,10 @@
 
   UserSchema.methods.verifyUserPassword = function(password) {
     if (password === undefined || password === null || password.length === 0) {
-      throw Error('No password to set.');
+      throw new Error('No password to set.');
     }
     if (password.length > MAX_PASSWORD_LENGTH) {
-      throw Error('Password is too long.');
+      throw new Error('Password is too long.');
     }
   };
 
@@ -52,7 +52,8 @@
   UserSchema.methods.setPassword = function(rawPassword, callback) {
     this.verifyUserPassword(rawPassword);
     var password = authUtils.makePassword(rawPassword);
-    this.model('User').findByIdAndUpdate(this._id, {$set: {password: password}}, function(err, user) {
+    var model = this.model('User');
+    model.findByIdAndUpdate(this._id, {$set: {password: password}}, function(err, user) {
       callback(err === null);
     });
   };

--- a/services/auth/strategies.js
+++ b/services/auth/strategies.js
@@ -38,13 +38,15 @@
         } else if (user === null) {
           done(null, false, {message: "Invalid username or password"});
         } else {
-          if (user.password === password) {
-            User.findOne({_id: user._id}, function(err, user) {
-              done(null, user);
-            });
-          } else {
-            done(null, false, {message: "Invalid username or password."});
-          }
+          user.checkPassword(password, function(isValid) {
+            if (isValid) {
+              User.findById(user._id, function(err, user) {
+                done(null, user);
+              });
+            } else {
+              done(null, false, {message: "Invalid username or password."});
+            }
+          });
         }
       });
     });
@@ -66,8 +68,10 @@
                 username: username,
                 email: username + '@' + settings.realm.toLowerCase()
               });
-              newUser.save(function(err, userSaved) {
-                done(null, newUser);
+              newUser.save(function(err, savedUser) {
+                savedUser.setUnusablePassword(function(result) {
+                  done(null, savedUser);
+                });
               });
             } else {
               done(null, user);
@@ -95,8 +99,10 @@
           username: username,
           email: username + '@' + settings.realm.toLowerCase()
         });
-        newUser.save(function (err) {
-          fn(null, newUser);
+        newUser.save(function (err, savedUser) {
+          savedUser.setUnusablePassword(function(result) {
+            fn(null, newUser);
+          });
         });
       } else {
         fn(null, user);

--- a/services/auth/utils.js
+++ b/services/auth/utils.js
@@ -24,7 +24,7 @@
 
   module.exports.checkPassword = function(rawPassword, password) {
     var parts = password.split(PASSWORD_SEPARATOR);
-    var iterations = parseInt(parts[1]);
+    var iterations = parseInt(parts[1], 10);
     var salt = parts[2];
     var originalHash = parts[3];
     var hash = crypto.pbkdf2Sync(rawPassword, salt, iterations, MAXLEN);

--- a/services/auth/utils.js
+++ b/services/auth/utils.js
@@ -1,0 +1,34 @@
+
+(function(module) {
+
+  'use strict';
+
+  var crypto = require('crypto');
+  var utils = require('../utils.js');
+
+  var ALGORIGTHM = 'pbkdf2';
+  var ITERATIONS = 24000;
+  var MAXLEN = 64;
+  var PASSWORD_SEPARATOR = '$';
+
+  /*
+   * pbkdf2 is used for making and checking password.
+   *
+   * Because we have to support 0.10.x of nodejs, SHA1 is used.
+   */
+  module.exports.makePassword = function(rawPassword) {
+    var salt = utils.randomString();
+    var hash = crypto.pbkdf2Sync(rawPassword, salt, ITERATIONS, MAXLEN).toString('hex');
+    return [ALGORIGTHM, ITERATIONS, salt, hash].join(PASSWORD_SEPARATOR);
+  };
+
+  module.exports.checkPassword = function(rawPassword, password) {
+    var parts = password.split(PASSWORD_SEPARATOR);
+    var iterations = parseInt(parts[1]);
+    var salt = parts[2];
+    var originalHash = parts[3];
+    var hash = crypto.pbkdf2Sync(rawPassword, salt, iterations, MAXLEN);
+    return hash.toString('hex') === originalHash;
+  };
+
+}(module));

--- a/services/utils.js
+++ b/services/utils.js
@@ -12,6 +12,7 @@
   var fs = require("fs");
   var path = require("path");
   var packageInfo = require("../package.json");
+  var crypto = require('crypto');
 
   /*
    * Return service principal name according to Kerberos v5 specification
@@ -107,6 +108,18 @@
   module.exports.getExtension = function(filename) {
     var i = filename.lastIndexOf('.');
     return (i < 0) ? '' : filename.substr(i);
+  };
+
+  module.exports.randomString = function(options) {
+    var options = options || {};
+    var size = options.size || 64;
+    var stringbuf = options.stringbuf || 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    var outbuf = [];
+    var len = stringbuf.length, floor = Math.floor, random = Math.random;
+    for (var i = 0; i < size; i++) {
+      outbuf.push(stringbuf[floor(random() * len)]);
+    }
+    return outbuf.join('');
   };
 
 }(module));

--- a/services/utils.js
+++ b/services/utils.js
@@ -111,12 +111,14 @@
   };
 
   module.exports.randomString = function(options) {
-    var options = options || {};
-    var size = options.size || 64;
-    var stringbuf = options.stringbuf || 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    var opts = options || {};
+    var size = opts.size || 64;
+    var stringbuf = opts.stringbuf || 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ' +
+                                      '0123456789';
     var outbuf = [];
     var len = stringbuf.length, floor = Math.floor, random = Math.random;
-    for (var i = 0; i < size; i++) {
+    var i;
+    for (i = 0; i < size; i++) {
       outbuf.push(stringbuf[floor(random() * len)]);
     }
     return outbuf.join('');

--- a/spec/node/service-strategy-test.js
+++ b/spec/node/service-strategy-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var assert = require('assert');
+var async = require('async');
+var krb5 = require('node-krb5');
+var strategies = require('../../services/auth/strategies');
+var User = require('../../models/user');
+
+
+describe('Test Kerberos strategy', function() {
+
+  var krb5_authenticate = null;
+  var username = 'cqi';
+  var password = 'It is secret.';
+
+  var user1 = null;
+
+  beforeEach(function(done) {
+    krb5_authenticate = krb5.authenticate;
+
+    /*
+     * Mock krb5.authenticate to make it always success
+     */
+    krb5.authenticate = function(principal, password, callback) {
+      callback(null);
+    };
+
+    user1 = new User({username: 'user1', email: 'user1@example.com'});
+    user1.save(function(err, savedUser) {
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    krb5.authenticate = krb5_authenticate;
+
+    async.parallel([
+      function(callback) {
+        User.findOneAndRemove({username: username}, function(err, removedUser) {
+          if (err) callback(err, null);
+          else callback(null, true);
+        });
+      },
+      function(callback) {
+        User.findOneAndRemove({username: user1.username}, function(err, removedUser) {
+          if (err) callback(err, null);
+          else callback(null, true);
+        });
+      }
+    ],
+    function(err, results) {
+      if (err) throw err;
+      done();
+    });
+  });
+
+  it('Authenticate with Kerberos credential.', function(done) {
+    strategies.kerberos._verify(username, password, function(err, user, info) {
+      if (err) throw err;
+
+      User.findOne({username: username}, 'username password', function(err, foundUser) {
+        assert.strictEqual(foundUser.username, username);
+        assert(foundUser.password.length > 0);
+        done();
+      });
+    });
+  });
+
+  it('Do not create user account for an existent Kerberos credential.', function(done) {
+    // Here, it doesn't matter what password is.
+    var _password = 'xxx';
+
+    strategies.kerberos._verify(user1.username, _password, function(err, user, info) {
+      if (err) throw err;
+
+      User.find({username: user1.username}, 'username password', function(err, users) {
+        assert.strictEqual(users.length, 1);
+
+        var foundUser = users[0];
+        assert.strictEqual(foundUser.username, user1.username);
+        assert.strictEqual(foundUser.password, '');
+
+        done();
+      });
+    });
+  });
+
+});

--- a/spec/node/service-utils-test.js
+++ b/spec/node/service-utils-test.js
@@ -1,0 +1,15 @@
+
+'use strict';
+
+var assert = require('assert');
+var utils = require('../../services/utils');
+
+
+describe('Test generate random string', function() {
+
+  it('get random string', function() {
+    var string = utils.randomString();
+    assert(string.length > 0);
+  });
+
+});

--- a/spec/node/services-auth-test.js
+++ b/spec/node/services-auth-test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var assert = require('assert');
+var utils = require('../../services/auth/utils');
+
+
+describe('Test password operations', function() {
+
+  it('make password', function() {
+    var password = utils.makePassword('admin');
+    assert(password.length > 0);
+  });
+
+  it('check a password', function() {
+    var rawPassword = 'do not tell u';
+    var password = utils.makePassword(rawPassword);
+    assert(utils.checkPassword('what?', password) === false);
+    assert(utils.checkPassword(rawPassword, password) === true);
+  });
+
+});

--- a/spec/node/user-test.js
+++ b/spec/node/user-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Initialize database connection
+var dbinit = require('./dbinit');
+
+var assert = require('assert');
+var User = require('../../models/user');
+
+
+describe('Test operations against User\'s password', function() {
+
+  var user = null;
+  var password = 'it is a secret ;)';
+
+  beforeEach(function(done) {
+    user = new User({username: 'cqi', email: 'cqi@example.com'});
+    user.save(function(err, savedUser) {
+      if (err) throw err;
+      done();
+    });
+  });
+
+  afterEach(function(done) {
+    user.remove(function(err, removedObject) {
+      done();
+    });
+  });
+
+  it('Set a password', function(done) {
+    user.setPassword(password, function(result) {
+      assert(result);
+      User.findById(user._id, 'password', function(err, foundUser) {
+        assert.notEqual(foundUser.password, '');
+        done();
+      });
+    });
+  });
+
+  it('Set an empty password', function() {
+    assert.throws(function() { user.setPassword(''); }, Error);
+    assert.throws(function() { user.setPassword(undefined); }, Error);
+    assert.throws(function() { user.setPassword(null); }, Error);
+  });
+
+  it('Set an unusable password', function(done) {
+    user.setUnusablePassword(function(result) {
+      assert(result);
+      User.findById(user._id, 'password', function(err, foundUser) {
+        assert.notEqual(foundUser.password, '');
+        done();
+      });
+    });
+  });
+
+  it('Check user\'s password', function(done) {
+    user.setPassword(password, function(result) {
+      User.findById(user._id, 'password', function(err, foundUser) {
+        user.checkPassword(password, function(result) {
+          assert(result);
+          done();
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
Empty password, where an empty string is stored in the password field of each
User document, has potential security problem. Set unusable password to newly
created user when using Kerberos and RemoteUser strategy.

The idea of setting unusable password is borrowed from django.contrib.auth.
Algorithm pbkdf2 is adapted as the default cryption algorithm. Due to the
limitation of old version of nodejs that we have to support, sha1 is used for
now instead of sha256. This can be changed in the future once Cantas moves to
most latest version.

Although this patch is for setting unusable password, the solution also allows
to encrypt an user's password before storing into database in a normal
authentication use case.