### PR TITLE
better make to run cantas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
+DISTRO_ID=`lsb_release -i | cut -f2`
 
+help:
+	@echo "Utility used while development"
+	@echo
+	@echo "Targets:"
+	@echo "    check: run tests and check code style"
+	@echo "    run: run server"
+
+.PHONY: check
 check:
 	@echo "Running tests"
 	@echo
@@ -7,3 +16,23 @@ check:
 	@echo "Checking code styles"
 	@echo
 	@sh ./scripts/lintcheck
+
+.PHONY: run
+run:
+	@if [ ! -e settings.json ]; then \
+		cp settings.json.example settings.json; \
+		echo "settings.json is just copied from an example file. You need to configure it to meet your requirement."; \
+	fi
+	@case "$(DISTRO_ID)" in \
+		Fedora) \
+			if [ x"`systemctl is-active mongod.service`" != "xactive" ]; then \
+				sudo systemctl start mongod.service; \
+			fi; \
+			if [ x"`systemctl is-active redis.service`" != "xactive" ]; then \
+				sudo systemctl start redis.service; \
+			fi; \
+			;; \
+		*) \
+			echo "You have to start mongodb and redis manually."; \
+	esac
+	@node app.js

--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,25 @@ help:
 	@echo "    check: run tests and check code style"
 	@echo "    run: run server"
 
-.PHONY: check
-check:
+.PHONY: test
+test:
 	@echo "Running tests"
 	@echo
 	@grunt test
-	@echo
+
+.PHONY: lint
+lint:
+	@if [ "`which nodelint &> /dev/null && echo 0 || echo 1`" != "0" ]; then \
+		echo "Cannot find command: nodeline"; \
+		echo ; \
+		exit 1; \
+	fi
 	@echo "Checking code styles"
 	@echo
 	@sh ./scripts/lintcheck
+
+.PHONY: check
+check: test lint
 
 .PHONY: run
 run:


### PR DESCRIPTION
mongodb and redis are necessary to run Cantas, especially in development. `make
run` will detect mongodb and redis and start them automatically if necessary on
behalf of you to give a convenient way. `make run` also give an example and
reference to developers to know what prerequisites are required to run Cantas.