### PR TITLE
make noreply email address and the email domain of invitation configurable

### DIFF
--- a/public/javascripts/views/boardMembers.js
+++ b/public/javascripts/views/boardMembers.js
@@ -116,7 +116,8 @@
           if (resp.isEmailAddr) {
             that.showValidationMessage(resp.username + " is not Cantas user, invite to Cantas?");
           } else if (resp.username.indexOf('@') !== -1) {
-            that.showValidationMessage(resp.username + " is not a REDHAT account.");
+            that.showValidationMessage("Cannot invite this person. " +
+                                       resp.username + " does not have a trusted domain.");
           }
           that.markMemberCandidateError(resp.username);
         }

--- a/services/mail.js
+++ b/services/mail.js
@@ -42,7 +42,7 @@ mailer.prototype.sendmail = function(options, callback) {
 };
 
 mailer.prototype.sendmailFromNoReply = function(options, callback) {
-  options.from = "noreply@redhat.com";
+  options.from = settings.mailServices.noreply_address;
   this.sendmail(options, callback);
 };
 

--- a/services/mail.js
+++ b/services/mail.js
@@ -42,7 +42,7 @@ mailer.prototype.sendmail = function(options, callback) {
 };
 
 mailer.prototype.sendmailFromNoReply = function(options, callback) {
-  options.from = settings.mailServices.noreply_address;
+  options.from = settings.mailServices.noreplyAddress;
   this.sendmail(options, callback);
 };
 

--- a/settings.json.example
+++ b/settings.json.example
@@ -14,7 +14,7 @@
             "clientSecret": ""
         }
     },
-    "trusted_domains": ["*"],
+    "trustedDomains": ["*"],
     "links": {
         "bugzilla": "",
         "hssPortal": ""
@@ -28,7 +28,7 @@
             "port": 25,
             "secureConnection": true
         },
-        "noreply_address": "noreply@example.com"
+        "noreplyAddress": "noreply@example.com"
     },
     "management": {
         "service": {

--- a/settings.json.example
+++ b/settings.json.example
@@ -14,6 +14,7 @@
             "clientSecret": ""
         }
     },
+    "trusted_domains": ["*"],
     "links": {
         "bugzilla": "",
         "hssPortal": ""
@@ -26,7 +27,8 @@
             "host": "mail.xxx.com",
             "port": 25,
             "secureConnection": true
-        }
+        },
+        "noreply_address": "noreply@example.com"
     },
     "management": {
         "service": {

--- a/sockets/boardMembership.js
+++ b/sockets/boardMembership.js
@@ -15,7 +15,7 @@
   var LogActivity = require("../services/activity").Activity;
   var settings = require("../settings");
 
-  var emailRegExps = settings.trusted_domains.map(function(trustedDomain) {
+  var emailRegExps = settings.trustedDomains.map(function(trustedDomain) {
     var domain = trustedDomain;
     if (domain === '*') {
       domain = '.+';

--- a/spec/node/mail-test.js
+++ b/spec/node/mail-test.js
@@ -63,7 +63,7 @@ describe("Test Mailer interface", function() {
       body: "Hello world."
     };
     mailer.sendmailFromNoReply(mailOptions, function(error, response) {
-      assert.equal(comingEmailMessage._message.from, "noreply@redhat.com");
+      assert.equal(comingEmailMessage._message.from, "noreply@example.com");
       assert.equal(comingEmailMessage._message.to, "cqi@redhat.com");
     })
     done();


### PR DESCRIPTION
noreply email address is configurable in a simple way.

the domain name of invitation email is no longer limited to a specific domain.
Multiple domain names can be specified to `trusted_domains`. If there is no
limitation, '*' is the right one. Anyway, when '*' and common domain names are
mixed, no limitation there eventually.